### PR TITLE
Fix the startup crash 

### DIFF
--- a/mods/tdx/mod.yaml
+++ b/mods/tdx/mod.yaml
@@ -108,6 +108,10 @@ TileSets:
 	./mods/tdx/tilesets/jungle.yaml
 	./mods/tdx/tilesets/caribic.yaml
 
+MapGrid:
+	Tilesize: 32,32
+	Type: Rectangle
+
 SupportsMapsFrom: cnc, tdx
 
 SpriteFormats: ShpTD, TmpTD, ShpTS, TmpRA

--- a/mods/tdx/mod.yaml
+++ b/mods/tdx/mod.yaml
@@ -162,7 +162,7 @@ Chrome:
 	./mods/tdx/ui/chrome.yaml
 
 ChromeLayout:
-#	./mods/tdx/ui/chrome/install.yaml
+	./mods/tdx/ui/chrome/install.yaml
 	./mods/ra/chrome/ingame.yaml
 	./mods/ra/chrome/ingame-chat.yaml
 	./mods/ra/chrome/ingame-diplomacy.yaml
@@ -175,12 +175,10 @@ ChromeLayout:
 	./mods/ra/chrome/ingame-menu.yaml
 	./mods/ra/chrome/ingame-observer.yaml
 	./mods/ra/chrome/ingame-observerstats.yaml
-#	./mods/tdx/ui/chrome/ingame-player.yaml
-	./mods/ra/chrome/ingame-player.yaml
+	./mods/tdx/ui/chrome/ingame-player.yaml
 	./mods/ra/chrome/ingame-perf.yaml
 	./mods/ra/chrome/ingame-debug.yaml
-#	./mods/tdx/ui/chrome/mainmenu.yaml
-	./mods/ra/chrome/mainmenu.yaml
+	./mods/tdx/ui/chrome/mainmenu.yaml
 	./mods/ra/chrome/settings.yaml
 	./mods/ra/chrome/credits.yaml
 	./mods/ra/chrome/lobby.yaml


### PR DESCRIPTION
Unfortunately there is another crash straight after loading, but it's different:

```
Tiberian Dawn Xtended Mod at Version beta 0.300 (20150920)
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.34209
Exception of type `System.InvalidOperationException`: Cannot locate type: WithMuzzleFlashInfo
   at OpenRA.ObjectCreator.<.cctor>b__13(String s) in \OpenRA\OpenRA.Game\ObjectCreator.cs:Line 46.
   at OpenRA.ObjectCreator.CreateObject[T](String className, Dictionary`2 args) in \OpenRA\OpenRA.Game\ObjectCreator.cs:Line 58.
   at OpenRA.ObjectCreator.CreateObject[T](String className) in \OpenRA\OpenRA.Game\ObjectCreator.cs:Line 50.
   at OpenRA.Game.CreateObject[T](String name) in \OpenRA\OpenRA.Game\Game.cs:Line 721.
   at OpenRA.ActorInfo.LoadTraitInfo(String traitName, MiniYaml my) in \OpenRA\OpenRA.Game\GameRules\ActorInfo.cs:Line 112.
   at OpenRA.ActorInfo..ctor(String name, MiniYaml node, Dictionary`2 allUnits) in \OpenRA\OpenRA.Game\GameRules\ActorInfo.cs:Line 55.
   at OpenRA.RulesetCache.<Load>b__0(MiniYamlNode k, Dictionary`2 y) in \OpenRA\OpenRA.Game\GameRules\RulesetCache.cs:Line 64.
   at OpenRA.RulesetCache.<>c__DisplayClass15`1.<LoadYamlRules>b__10(MiniYamlNode wkv, Dictionary`2 wyy) in \OpenRA\OpenRA.Game\GameRules\RulesetCache.cs:Line 113.
   at OpenRA.RulesetCache.<>c__DisplayClass15`1.<LoadYamlRules>b__14(MiniYamlNode kv) in \OpenRA\OpenRA.Game\GameRules\RulesetCache.cs:Line 121.
   at OpenRA.Exts.ToDictionaryWithConflictLog[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, String debugName, Func`2 logKey, Func`2 logValue) in \OpenRA\OpenRA.Game\Exts.cs:Line 365.
   at OpenRA.RulesetCache.LoadYamlRules[T](Dictionary`2 itemCache, String[] files, List`1 nodes, Func`3 f) in \OpenRA\OpenRA.Game\GameRules\RulesetCache.cs:Line 121.
   at OpenRA.RulesetCache.Load(Map map) in \OpenRA\OpenRA.Game\GameRules\RulesetCache.cs:Line 62.
   at OpenRA.ModData.<.ctor>b__2() in \OpenRA\OpenRA.Game\ModData.cs:Line 82.
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at System.Lazy`1.get_Value()
   at OpenRA.ModData.get_DefaultRules() in \OpenRA\OpenRA.Game\ModData.cs:Line 35.
   at OpenRA.Map.<PostInit>b__b() in \OpenRA\OpenRA.Game\Map\Map.cs:Line 409.
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at System.Lazy`1.get_Value()
   at OpenRA.Map.PreloadRules() in \OpenRA\OpenRA.Game\Map\Map.cs:Line 532.
   at OpenRA.ModData.PrepareMap(String uid) in \OpenRA\OpenRA.Game\ModData.cs:Line 170.
   at OpenRA.Game.StartGame(String mapUID, WorldType type) in \OpenRA\OpenRA.Game\Game.cs:Line 149.
   at OpenRA.Game.LoadShellMap() in \OpenRA\OpenRA.Game\Game.cs:Line 367.
   at OpenRA.Mods.Common.LoadScreens.BlankLoadScreen.StartGame(Arguments args)
   at OpenRA.Game.InitializeMod(String mod, Arguments args) in \OpenRA\OpenRA.Game\Game.cs:Line 354.
   at OpenRA.Game.Initialize(Arguments args) in \OpenRA\OpenRA.Game\Game.cs:Line 244.
   at OpenRA.Program.Run(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 115.
   at OpenRA.Program.Main(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 39.
```

CC @penev92.
