### PR TITLE
Fix juggernaut barrel pitch

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -349,7 +349,7 @@ namespace OpenRA
 					if (parts.Length == 3)
 					{
 						int rr, rp, ry;
-						if (Exts.TryParseIntegerInvariant(value, out rr) && Exts.TryParseIntegerInvariant(value, out rp) && Exts.TryParseIntegerInvariant(value, out ry))
+						if (Exts.TryParseIntegerInvariant(parts[0], out rr) && Exts.TryParseIntegerInvariant(parts[1], out rp) && Exts.TryParseIntegerInvariant(parts[2], out ry))
 							return new WRot(new WAngle(rr), new WAngle(rp), new WAngle(ry));
 					}
 				}

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -29,6 +29,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Visual offset")]
 		public readonly WVec LocalOffset = WVec.Zero;
 
+		[Desc("Rotate the barrel relative to the body")]
+		public readonly WRot LocalOrientation = WRot.Zero;
+
 		[Desc("Defines if the Voxel should have a shadow.")]
 		public readonly bool ShowShadow = true;
 
@@ -103,6 +106,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			var b = self.Orientation;
 			var qb = body.QuantizeOrientation(self, b);
+			yield return Info.LocalOrientation;
 			yield return turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw);
 			yield return qb;
 		}

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -343,7 +343,8 @@ JUGG:
 		RealignDelay: -1
 	WithVoxelBarrel:
 		Armament: deployed
-		LocalOffset: 363,0,-180
+		LocalOffset: 363,0,256
+		LocalOrientation: 0, 128, 0
 		RequiresCondition: deployed
 	WithSpriteTurret@deployed:
 		Turret: deployed


### PR DESCRIPTION
Implements a visual workaround until we can implement a proper automatic pitch calculation.  I have set up the barrel position, but you will need to move the Armament offsets to match.